### PR TITLE
Add 'licences' field to stemcell cloud-config

### DIFF
--- a/src/bosh-google-cpi/action/cloud_properties.go
+++ b/src/bosh-google-cpi/action/cloud_properties.go
@@ -29,10 +29,11 @@ type SnapshotMetadata struct {
 }
 
 type StemcellCloudProperties struct {
-	Name           string `json:"name,omitempty"`
-	Version        string `json:"version,omitempty"`
-	Infrastructure string `json:"infrastructure,omitempty"`
-	SourceURL      string `json:"source_url,omitempty"`
+	Name           string   `json:"name,omitempty"`
+	Version        string   `json:"version,omitempty"`
+	Infrastructure string   `json:"infrastructure,omitempty"`
+	Licences       []string `json:"licences,omitempty"`
+	SourceURL      string   `json:"source_url,omitempty"`
 
 	// URL of an existing image (Image.SelfLink)
 	ImageURL   string `json:"image_url,omitempty"`

--- a/src/bosh-google-cpi/action/create_stemcell.go
+++ b/src/bosh-google-cpi/action/create_stemcell.go
@@ -38,9 +38,9 @@ func (cs CreateStemcell) Run(stemcellPath string, cloudProps StemcellCloudProper
 	case cloudProps.ImageURL != "":
 		stemcell = cloudProps.ImageURL
 	case cloudProps.SourceURL != "":
-		stemcell, err = cs.imageService.CreateFromURL(cloudProps.SourceURL, cloudProps.SourceSha1, description)
+		stemcell, err = cs.imageService.CreateFromURL(cloudProps.SourceURL, cloudProps.SourceSha1, description, cloudProps.Licences)
 	default:
-		stemcell, err = cs.imageService.CreateFromTarball(stemcellPath, description)
+		stemcell, err = cs.imageService.CreateFromTarball(stemcellPath, description, cloudProps.Licences)
 	}
 	if err != nil {
 		return "", bosherr.WrapError(err, "Creating stemcell")

--- a/src/bosh-google-cpi/google/image_service/fakes/fake_image_service.go
+++ b/src/bosh-google-cpi/google/image_service/fakes/fake_image_service.go
@@ -27,7 +27,7 @@ type FakeImageService struct {
 	FindErr    error
 }
 
-func (i *FakeImageService) CreateFromURL(sourceURL string, sourceSha1 string, description string) (string, error) {
+func (i *FakeImageService) CreateFromURL(sourceURL string, sourceSha1 string, description string, licences []string) (string, error) {
 	i.CreateFromURLCalled = true
 	i.CreateFromURLSourceURL = sourceURL
 	i.CreateFromURLSourceSha1 = sourceSha1
@@ -35,7 +35,7 @@ func (i *FakeImageService) CreateFromURL(sourceURL string, sourceSha1 string, de
 	return i.CreateFromURLID, i.CreateFromURLErr
 }
 
-func (i *FakeImageService) CreateFromTarball(imagePath string, description string) (string, error) {
+func (i *FakeImageService) CreateFromTarball(imagePath string, description string, licences []string) (string, error) {
 	i.CreateFromTarballCalled = true
 	i.CreateFromTarballImagePath = imagePath
 	i.CreateFromTarballDescription = description

--- a/src/bosh-google-cpi/google/image_service/google_image_service_create.go
+++ b/src/bosh-google-cpi/google/image_service/google_image_service_create.go
@@ -16,14 +16,14 @@ func (i GoogleImageService) cleanUp(id string) {
 	}
 }
 
-func (i GoogleImageService) CreateFromURL(sourceURL string, sourceSha1 string, description string) (string, error) {
+func (i GoogleImageService) CreateFromURL(sourceURL string, sourceSha1 string, description string, licences []string) (string, error) {
 	uuidStr, err := i.uuidGen.Generate()
 	if err != nil {
 		return "", bosherr.WrapErrorf(err, "Generating random Google Image name")
 	}
 
 	imageName := fmt.Sprintf("%s-%s", googleImageNamePrefix, uuidStr)
-	image, err := i.create(imageName, description, sourceURL, sourceSha1)
+	image, err := i.create(imageName, description, sourceURL, sourceSha1, licences)
 	if err != nil {
 		return "", bosherr.WrapErrorf(err, "Creating Google Image from URL")
 	}
@@ -31,7 +31,7 @@ func (i GoogleImageService) CreateFromURL(sourceURL string, sourceSha1 string, d
 	return image, nil
 }
 
-func (i GoogleImageService) CreateFromTarball(imagePath string, description string) (string, error) {
+func (i GoogleImageService) CreateFromTarball(imagePath string, description string, licences []string) (string, error) {
 	uuidStr, err := i.uuidGen.Generate()
 	if err != nil {
 		return "", bosherr.WrapErrorf(err, "Generating random Google Image name")
@@ -80,7 +80,7 @@ func (i GoogleImageService) CreateFromTarball(imagePath string, description stri
 	defer i.deleteObject(imageName, objectName)
 
 	// Create the image
-	image, err := i.create(imageName, description, imageObject.MediaLink, "")
+	image, err := i.create(imageName, description, imageObject.MediaLink, "", licences)
 	if err != nil {
 		return "", bosherr.WrapErrorf(err, "Creating Google Image from Tarball")
 	}
@@ -88,7 +88,7 @@ func (i GoogleImageService) CreateFromTarball(imagePath string, description stri
 	return image, nil
 }
 
-func (i GoogleImageService) create(name string, description string, sourceURL string, sourceSha1 string) (string, error) {
+func (i GoogleImageService) create(name string, description string, sourceURL string, sourceSha1 string, licences []string) (string, error) {
 	if description == "" {
 		description = googleImageDescription
 	}
@@ -102,6 +102,7 @@ func (i GoogleImageService) create(name string, description string, sourceURL st
 		Name:        name,
 		Description: description,
 		RawDisk:     rawdisk,
+		Licenses:    licences,
 	}
 
 	i.logger.Debug(googleImageServiceLogTag, "Creating Google Image with params: %#v", image)

--- a/src/bosh-google-cpi/google/image_service/image_service.go
+++ b/src/bosh-google-cpi/google/image_service/image_service.go
@@ -1,8 +1,8 @@
 package image
 
 type Service interface {
-	CreateFromURL(sourceURL string, sourceSha1 string, description string) (string, error)
-	CreateFromTarball(imagePath string, description string) (string, error)
+	CreateFromURL(sourceURL string, sourceSha1 string, description string, licences []string) (string, error)
+	CreateFromTarball(imagePath string, description string, licences []string) (string, error)
 	Delete(id string) error
 	Find(id string) (Image, bool, error)
 }


### PR DESCRIPTION
To enable vmx extensions on GCP whilst in beta, a licence needs to be added to the stemcell a machine is created from.

https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances

Not sure if this belongs in `master` as apparently `vmx` will be enabled by default when it gets out of beta, but here it is if anybody finds it useful until then.