### PR TITLE
Avoid keeping old golang installation files in GOROOT

### DIFF
--- a/packages/golang/packaging
+++ b/packages/golang/packaging
@@ -10,4 +10,4 @@ tar xzvf ${BOSH_COMPILE_TARGET}/golang/go${GOLANG_VERSION}.${PLATFORM}-amd64.tar
 
 # Copy Go Programming Language package
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
-cp -a ${BOSH_COMPILE_TARGET}/go/* ${BOSH_INSTALL_TARGET}
+cp -R ${BOSH_COMPILE_TARGET}/go/* ${BOSH_INSTALL_TARGET}


### PR DESCRIPTION
- this will fix the following issue: https://github.com/cloudfoundry/bosh-google-cpi-release/issues/288


Co-authored-by: Christopher Hunter <hunter.christopher@icloud.com>