### PR TITLE
Clear IP on dynamic network

### DIFF
--- a/src/bosh-google-cpi/action/concrete_factory_test.go
+++ b/src/bosh-google-cpi/action/concrete_factory_test.go
@@ -17,7 +17,6 @@ import (
 	"bosh-google-cpi/google/disk_service"
 	"bosh-google-cpi/google/disk_type_service"
 	"bosh-google-cpi/google/image_service"
-	"bosh-google-cpi/google/instance_group_service"
 	"bosh-google-cpi/google/instance_service"
 	"bosh-google-cpi/google/machine_type_service"
 	"bosh-google-cpi/google/network_service"
@@ -61,7 +60,6 @@ var _ = Describe("ConcreteFactory", func() {
 		diskService            disk.Service
 		diskTypeService        disktype.Service
 		imageService           image.Service
-		instanceGroupService   instancegroup.Service
 		backendServiceService  backendservice.Service
 		machineTypeService     machinetype.Service
 		acceleratorTypeService acceleratortype.Service
@@ -131,13 +129,6 @@ var _ = Describe("ConcreteFactory", func() {
 		)
 
 		backendServiceService = backendservice.NewGoogleBackendServiceService(
-			ctx["project"].(string),
-			googleClient.ComputeService(),
-			operationService,
-			logger,
-		)
-
-		instanceGroupService = instancegroup.NewGoogleInstanceGroupService(
 			ctx["project"].(string),
 			googleClient.ComputeService(),
 			operationService,

--- a/src/bosh-google-cpi/action/create_vm.go
+++ b/src/bosh-google-cpi/action/create_vm.go
@@ -106,6 +106,9 @@ func (cv CreateVM) Run(agentID string, stemcellCID StemcellCID, cloudProps VMClo
 	if cloudProps.EphemeralExternalIP != nil {
 		vmNetworks.Network().EphemeralExternalIP = *cloudProps.EphemeralExternalIP
 	}
+	if vmNetworks.Network().Type == "dynamic" {
+		vmNetworks.Network().IP = ""
+	}
 
 	// Extract any tags from env.bosh.groups
 	if boshenv, ok := env["bosh"]; ok {

--- a/src/bosh-google-cpi/action/create_vm_test.go
+++ b/src/bosh-google-cpi/action/create_vm_test.go
@@ -16,6 +16,7 @@ import (
 	machinetypefakes "bosh-google-cpi/google/machine_type_service/fakes"
 	"bosh-google-cpi/registry"
 	"errors"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -114,7 +115,7 @@ var _ = Describe("CreateVM", func() {
 
 			networks = Networks{
 				"fake-network-name": &Network{
-					Type:    "dynamic",
+					Type:    "manual",
 					IP:      "fake-network-ip",
 					Gateway: "fake-network-gateway",
 					Netmask: "fake-network-netmask",
@@ -157,7 +158,7 @@ var _ = Describe("CreateVM", func() {
 				Mbus: "http://fake-mbus",
 				Networks: registry.NetworksSettings{
 					"fake-network-name": registry.NetworkSettings{
-						Type:    "dynamic",
+						Type:    "manual",
 						IP:      "fake-network-ip",
 						Gateway: "fake-network-gateway",
 						Netmask: "fake-network-netmask",
@@ -754,6 +755,20 @@ var _ = Describe("CreateVM", func() {
 					Expect(vmService.CleanUpCalled).To(BeFalse())
 					Expect(registryClient.UpdateCalled).To(BeFalse())
 				})
+			})
+		})
+
+		Context("when network is of type 'dynamic'", func() {
+			BeforeEach(func() {
+				networks["fake-network-name"].Type = "dynamic"
+				expectedInstanceNetworks.Network().Type = "dynamic"
+				expectedInstanceNetworks.Network().IP = ""
+			})
+
+			It("clear out the ip part of the network settings", func() {
+				vmCID, err = createVM.Run("fake-agent-id", "fake-stemcell-id", cloudProps, networks, disks, env)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(vmService.CreateNetworks).To(Equal(expectedInstanceNetworks))
 			})
 		})
 	})


### PR DESCRIPTION
We noticed that when using the `create-swap-delete` [VM update strategy](https://bosh.io/docs/changing-deployment-vm-strategy/#usage) and dynamic networks with the Google CPI, we consistently get the following error:

```
                   L Error: CPI error 'Bosh::Clouds::VMCreationFailed' with message 'VM failed to create: Google Operation 'operation-1541629462868-57a1a94827020-98416a05-e8297474' finished with an error: IP '10.0.0.2' is already being used by another resource. 
```

According to what other CPIs do, we should be ignoring that IP parameter when the network type is `dynamic`. This PR removed the IP before sending the create VM call to the IaaS to get around this issue.

We also had to remove an unused variable from `concrete_factory_test.go` because that no longer compiles on Go 1.11.

It seems that this issue is similar to #191, but we aren't sure if this fix would also fix their problem.