### PR TITLE
WIP: Error if disk is already attached

### DIFF
--- a/src/bosh-google-cpi/action/attach_disk.go
+++ b/src/bosh-google-cpi/action/attach_disk.go
@@ -1,6 +1,8 @@
 package action
 
 import (
+	"strings"
+
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 
 	"bosh-google-cpi/api"
@@ -37,30 +39,61 @@ func (ad AttachDisk) Run(vmCID VMCID, diskCID DiskCID) (interface{}, error) {
 	if !found {
 		return nil, api.NewDiskNotFoundError(string(diskCID), false)
 	}
+
+	// If the persistent disk is already attached to the VM, only attempt the
+	// BOSH agent attachment.
+	if diskAttachedToVM(vmCID, disk.Users) {
+		return nil, nil
+	}
+
+	// If this disk is attached to another VM, attaching here will fail so return
+	// a useful error before trying.
 	if len(disk.Users) > 0 {
 		return nil, api.NewDiskAlreadyAttachedError(string(diskCID), disk.Users, false)
 	}
 
-	// Atach the Disk to the VM
-	deviceName, devicePath, err := ad.vmService.AttachDisk(string(vmCID), disk.SelfLink)
+	err, deviceName, devicePath := ad.gceAttach(vmCID, diskCID, disk.SelfLink)
 	if err != nil {
-		if _, ok := err.(api.CloudError); ok {
-			return nil, err
-		}
-		return nil, bosherr.WrapErrorf(err, "Attaching disk '%s' to vm '%s'", diskCID, vmCID)
+		return nil, err
 	}
 
+	err = ad.agentAttach(vmCID, diskCID, deviceName, devicePath)
+	return nil, err
+}
+
+func (ad AttachDisk) gceAttach(vmCID VMCID, diskCID DiskCID, diskSelfLink string) (error, string, string) {
+	// Atach the Disk to the VM
+	deviceName, devicePath, err := ad.vmService.AttachDisk(string(vmCID), diskSelfLink)
+	if err != nil {
+		if _, ok := err.(api.CloudError); ok {
+			return err, deviceName, devicePath
+		}
+		return bosherr.WrapErrorf(err, "Attaching disk '%s' to vm '%s'", diskCID, vmCID), deviceName, devicePath
+	}
+	return nil, deviceName, devicePath
+}
+
+func (ad AttachDisk) agentAttach(vmCID VMCID, diskCID DiskCID, deviceName string, devicePath string) error {
 	// Read VM agent settings
 	agentSettings, err := ad.registryClient.Fetch(string(vmCID))
 	if err != nil {
-		return nil, bosherr.WrapErrorf(err, "Attaching disk '%s' to vm '%s'", diskCID, vmCID)
+		return bosherr.WrapErrorf(err, "Attaching disk '%s' to vm '%s'", diskCID, vmCID)
 	}
 
 	// Update VM agent settings
 	newAgentSettings := agentSettings.AttachPersistentDisk(string(diskCID), deviceName, devicePath)
 	if err = ad.registryClient.Update(string(vmCID), newAgentSettings); err != nil {
-		return nil, bosherr.WrapErrorf(err, "Attaching disk '%s' to vm '%s'", diskCID, vmCID)
+		return bosherr.WrapErrorf(err, "Attaching disk '%s' to vm '%s'", diskCID, vmCID)
 	}
+	return nil
+}
 
-	return nil, nil
+// This function returns true if the VM has the disk attached.
+func diskAttachedToVM(vmCID VMCID, diskUsers []string) bool {
+	for _, v := range diskUsers {
+		if strings.HasSuffix(v, string(vmCID)) {
+			return true
+		}
+	}
+	return false
 }

--- a/src/bosh-google-cpi/action/attach_disk.go
+++ b/src/bosh-google-cpi/action/attach_disk.go
@@ -37,6 +37,9 @@ func (ad AttachDisk) Run(vmCID VMCID, diskCID DiskCID) (interface{}, error) {
 	if !found {
 		return nil, api.NewDiskNotFoundError(string(diskCID), false)
 	}
+	if len(disk.Users) > 0 {
+		return nil, api.NewDiskAlreadyAttachedError(string(diskCID), disk.Users, false)
+	}
 
 	// Atach the Disk to the VM
 	deviceName, devicePath, err := ad.vmService.AttachDisk(string(vmCID), disk.SelfLink)

--- a/src/bosh-google-cpi/action/attach_disk_test.go
+++ b/src/bosh-google-cpi/action/attach_disk_test.go
@@ -127,5 +127,15 @@ var _ = Describe("AttachDisk", func() {
 			Expect(registryClient.FetchCalled).To(BeTrue())
 			Expect(registryClient.UpdateCalled).To(BeTrue())
 		})
+
+		It("returns an error if disk is attached to any other VM", func() {
+			diskService.FindDisk = disk.Disk{Name: "fake-disk-1", Users: []string{"fake-user-2"}}
+			vmService.AttachDiskErr = errors.New("fake-vm-service-error")
+
+			_, err = attachDisk.Run("fake-vm-id", "fake-disk-id")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("is already attached"))
+		})
+
 	})
 })

--- a/src/bosh-google-cpi/action/attach_disk_test.go
+++ b/src/bosh-google-cpi/action/attach_disk_test.go
@@ -128,6 +128,14 @@ var _ = Describe("AttachDisk", func() {
 			Expect(registryClient.UpdateCalled).To(BeTrue())
 		})
 
+		It("returns if disk is attached to the same VM", func() {
+			diskService.FindDisk = disk.Disk{Name: "fake-disk-1", Users: []string{"fake-vm-id"}}
+			vmService.AttachDiskErr = errors.New("fake-vm-service-error")
+
+			_, err = attachDisk.Run("fake-vm-id", "fake-disk-id")
+			Expect(err).To(Not(HaveOccurred()))
+		})
+
 		It("returns an error if disk is attached to any other VM", func() {
 			diskService.FindDisk = disk.Disk{Name: "fake-disk-1", Users: []string{"fake-user-2"}}
 			vmService.AttachDiskErr = errors.New("fake-vm-service-error")

--- a/src/bosh-google-cpi/action/attach_disk_test.go
+++ b/src/bosh-google-cpi/action/attach_disk_test.go
@@ -130,20 +130,9 @@ var _ = Describe("AttachDisk", func() {
 
 		It("returns if disk is attached to the same VM", func() {
 			diskService.FindDisk = disk.Disk{Name: "fake-disk-1", Users: []string{"fake-vm-id"}}
-			vmService.AttachDiskErr = errors.New("fake-vm-service-error")
 
 			_, err = attachDisk.Run("fake-vm-id", "fake-disk-id")
 			Expect(err).To(Not(HaveOccurred()))
 		})
-
-		It("returns an error if disk is attached to any other VM", func() {
-			diskService.FindDisk = disk.Disk{Name: "fake-disk-1", Users: []string{"fake-user-2"}}
-			vmService.AttachDiskErr = errors.New("fake-vm-service-error")
-
-			_, err = attachDisk.Run("fake-vm-id", "fake-disk-id")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("is already attached"))
-		})
-
 	})
 })

--- a/src/bosh-google-cpi/action/concrete_factory.go
+++ b/src/bosh-google-cpi/action/concrete_factory.go
@@ -220,8 +220,8 @@ func (f ConcreteFactory) Create(method string, ctx map[string]interface{}) (Acti
 		"get_disks":          NewGetDisks(vmService),
 
 		// Others:
-		"info": NewInfo(),
-		"ping": NewPing(),
+		"info":                          NewInfo(),
+		"ping":                          NewPing(),
 		"calculate_vm_cloud_properties": NewCalculateVMCloudProperties(),
 
 		// Not implemented:

--- a/src/bosh-google-cpi/api/errors.go
+++ b/src/bosh-google-cpi/api/errors.go
@@ -86,19 +86,3 @@ func NewDiskNotFoundError(diskID string, canRetry bool) DiskNotFoundError {
 func (e DiskNotFoundError) Type() string   { return "Bosh::Clouds::DiskNotFound" }
 func (e DiskNotFoundError) Error() string  { return fmt.Sprintf("Disk '%s' not found", e.diskID) }
 func (e DiskNotFoundError) CanRetry() bool { return e.canRetry }
-
-type DiskAlreadyAttachedError struct {
-	diskID   string
-	users    []string
-	canRetry bool
-}
-
-func NewDiskAlreadyAttachedError(diskID string, users []string, canRetry bool) DiskAlreadyAttachedError {
-	return DiskAlreadyAttachedError{diskID: diskID, users: users, canRetry: canRetry}
-}
-
-func (e DiskAlreadyAttachedError) Type() string { return "Bosh::Clouds::DiskAlreadyAttached" }
-func (e DiskAlreadyAttachedError) Error() string {
-	return fmt.Sprintf("Disk '%s' is already attached to '%s'", e.diskID, e.users)
-}
-func (e DiskAlreadyAttachedError) CanRetry() bool { return e.canRetry }

--- a/src/bosh-google-cpi/api/errors.go
+++ b/src/bosh-google-cpi/api/errors.go
@@ -86,3 +86,19 @@ func NewDiskNotFoundError(diskID string, canRetry bool) DiskNotFoundError {
 func (e DiskNotFoundError) Type() string   { return "Bosh::Clouds::DiskNotFound" }
 func (e DiskNotFoundError) Error() string  { return fmt.Sprintf("Disk '%s' not found", e.diskID) }
 func (e DiskNotFoundError) CanRetry() bool { return e.canRetry }
+
+type DiskAlreadyAttachedError struct {
+	diskID   string
+	users    []string
+	canRetry bool
+}
+
+func NewDiskAlreadyAttachedError(diskID string, users []string, canRetry bool) DiskAlreadyAttachedError {
+	return DiskAlreadyAttachedError{diskID: diskID, users: users, canRetry: canRetry}
+}
+
+func (e DiskAlreadyAttachedError) Type() string { return "Bosh::Clouds::DiskAlreadyAttached" }
+func (e DiskAlreadyAttachedError) Error() string {
+	return fmt.Sprintf("Disk '%s' is already attached to '%s'", e.diskID, e.users)
+}
+func (e DiskAlreadyAttachedError) CanRetry() bool { return e.canRetry }

--- a/src/bosh-google-cpi/google/disk_service/disk.go
+++ b/src/bosh-google-cpi/google/disk_service/disk.go
@@ -5,4 +5,5 @@ type Disk struct {
 	SelfLink string
 	Status   string
 	Zone     string
+	Users    []string
 }

--- a/src/bosh-google-cpi/google/disk_service/google_disk_service_find.go
+++ b/src/bosh-google-cpi/google/disk_service/google_disk_service_find.go
@@ -26,6 +26,7 @@ func (d GoogleDiskService) Find(id string, zone string) (Disk, bool, error) {
 					SelfLink: diskItem.SelfLink,
 					Status:   diskItem.Status,
 					Zone:     diskItem.Zone,
+					Users:    diskItem.Users,
 				}
 				return disk, true, nil
 			}

--- a/src/bosh-google-cpi/google/instance_service/fakes/fake_instance_service.go
+++ b/src/bosh-google-cpi/google/instance_service/fakes/fake_instance_service.go
@@ -36,6 +36,8 @@ type FakeInstanceService struct {
 	DetachDiskCalled bool
 	DetachDiskErr    error
 
+	DiskDetailCalled bool
+
 	FindCalled   bool
 	FindFound    bool
 	FindInstance *compute.Instance
@@ -60,9 +62,17 @@ func (i *FakeInstanceService) AddAccessConfig(id string, zone string, networkInt
 	return i.AddAccessConfigErr
 }
 
-func (i *FakeInstanceService) AttachDisk(id string, diskLink string) (string, string, error) {
+func (i *FakeInstanceService) AttachDisk(id string, diskLink string) (*instance.DiskAttachmentDetail, error) {
 	i.AttachDiskCalled = true
-	return i.AttachDiskDeviceName, i.AttachDiskDevicePath, i.AttachDiskErr
+	return i.DiskDetail(id, diskLink)
+}
+
+func (i *FakeInstanceService) DiskDetail(vmID string, diskLink string) (*instance.DiskAttachmentDetail, error) {
+	i.DiskDetailCalled = true
+	return &instance.DiskAttachmentDetail{
+		Name: i.AttachDiskDeviceName,
+		Path: i.AttachDiskDevicePath,
+	}, i.AttachDiskErr
 }
 
 func (i *FakeInstanceService) AttachedDisks(id string) (instance.AttachedDisks, error) {

--- a/src/bosh-google-cpi/google/instance_service/instance_service.go
+++ b/src/bosh-google-cpi/google/instance_service/instance_service.go
@@ -6,8 +6,9 @@ import (
 
 type Service interface {
 	AddAccessConfig(id string, zone string, networkInterface string, accessConfig *compute.AccessConfig) error
-	AttachDisk(id string, diskLink string) (string, string, error)
+	AttachDisk(id string, diskLink string) (*DiskAttachmentDetail, error)
 	AttachedDisks(id string) (AttachedDisks, error)
+	DiskDetail(vmID string, diskLink string) (*DiskAttachmentDetail, error)
 	CleanUp(id string)
 	Create(vmProps *Properties, networks Networks, registryEndpoint string) (string, error)
 	Delete(id string) error
@@ -52,4 +53,8 @@ type BackendService struct {
 type Accelerator struct {
 	AcceleratorType string
 	Count           int64
+}
+type DiskAttachmentDetail struct {
+	Name string
+	Path string
 }

--- a/src/bosh-google-cpi/integration/disk_test.go
+++ b/src/bosh-google-cpi/integration/disk_test.go
@@ -66,6 +66,13 @@ var _ = Describe("Disk", func() {
 		disks := toStringArray(assertSucceedsWithResult(request).([]interface{}))
 		Expect(disks).To(ContainElement(diskCID))
 
+		By("attaching the disk again without failing")
+		request = fmt.Sprintf(`{
+			  "method": "attach_disk",
+			  "arguments": ["%v", "%v"]
+			}`, vmCID, diskCID)
+		assertSucceeds(request)
+
 		By("detaching and deleting a disk")
 		request = fmt.Sprintf(`{
 			  "method": "detach_disk",


### PR DESCRIPTION
This change addresses #280. If a disk is already attached to another VM, the attack disk will not attempt to attach it to another VM.

- [x] Add integration test