### PR TITLE
limits needing to have compute.network.Viewer on shared host project 

### DIFF
--- a/.final_builds/packages/bosh-google-cpi/index.yml
+++ b/.final_builds/packages/bosh-google-cpi/index.yml
@@ -108,4 +108,8 @@ builds:
     version: 1070e940b5e8375f19fecceba27ba02ce0a2177a
     sha1: 840bb779189f6af8fb028ebacc158f1e0cad9fbb
     blobstore_id: ee5618f9-063b-468f-b38e-208fa864eb9c
+  23e0ad9150555a5d4292442722e6ced8247677ed:
+    version: 23e0ad9150555a5d4292442722e6ced8247677ed
+    sha1: e3efdf90fa1cbb63c39b2a3593c6ba7eab1fa9de
+    blobstore_id: 70a37ba9-d6e4-4db9-936e-b66b9bd19439
 format-version: '2'

--- a/releases/bosh-google-cpi/bosh-google-cpi-29.0.1.yml
+++ b/releases/bosh-google-cpi/bosh-google-cpi-29.0.1.yml
@@ -1,0 +1,26 @@
+---
+name: bosh-google-cpi
+version: 29.0.1
+commit_hash: b90a761
+uncommitted_changes: true
+jobs:
+- name: google_cpi
+  version: a535aaf7b4b48cebaa385d70374b2d5730f3fa81
+  fingerprint: a535aaf7b4b48cebaa385d70374b2d5730f3fa81
+  sha1: d9210ba2f3306c64598bb5a6c29c3b82ed53bb65
+packages:
+- name: bosh-google-cpi
+  version: 23e0ad9150555a5d4292442722e6ced8247677ed
+  fingerprint: 23e0ad9150555a5d4292442722e6ced8247677ed
+  sha1: e3efdf90fa1cbb63c39b2a3593c6ba7eab1fa9de
+  dependencies:
+  - golang
+- name: golang
+  version: e103ebf92cdbc41ef084dd08db049086dcbcd904
+  fingerprint: e103ebf92cdbc41ef084dd08db049086dcbcd904
+  sha1: 1b7031b4d4beb53deade6e4f377f99406f8cfade
+  dependencies: []
+license:
+  version: 6c877ca82c86aee278cd056b02485e44e39ed739
+  fingerprint: 6c877ca82c86aee278cd056b02485e44e39ed739
+  sha1: b0afd4bd44a84c6a4abe071b49f36d66bed632fa

--- a/releases/bosh-google-cpi/index.yml
+++ b/releases/bosh-google-cpi/index.yml
@@ -88,4 +88,6 @@ builds:
     version: 28.0.1
   9b953e11-edde-4ab5-bb18-2daef89b70e8:
     version: 29.0.0
+  68446695-7ed5-49b0-b79d-fb8d455888f3:
+    version: 29.0.1
 format-version: '2'

--- a/src/bosh-google-cpi/google/instance_service/google_instance_service_create.go
+++ b/src/bosh-google-cpi/google/instance_service/google_instance_service_create.go
@@ -173,15 +173,8 @@ func (i GoogleInstanceService) createMatadataParams(name string, regEndpoint str
 }
 
 func (i GoogleInstanceService) createNetworkInterfacesParams(networks Networks, zone string) ([]*compute.NetworkInterface, error) {
-	network, found, err := i.networkService.Find(networks.NetworkProjectID(), networks.NetworkName())
-	if err != nil {
-		return nil, err
-	}
-	if !found {
-		return nil, bosherr.WrapErrorf(err, "Network '%s' does not exist in project '%s'", networks.NetworkName(), networks.NetworkProjectID())
-	}
-
 	subnetworkLink := ""
+	networkLink := ""
 	if networks.SubnetworkName() != "" {
 		subnetwork, err := i.subnetworkService.Find(networks.NetworkProjectID(), networks.SubnetworkName(), util.RegionFromZone(zone))
 		if err != nil {
@@ -191,6 +184,7 @@ func (i GoogleInstanceService) createNetworkInterfacesParams(networks Networks, 
 			return nil, err
 		}
 		subnetworkLink = subnetwork.SelfLink
+		networkLink = subnetwork.Network
 	}
 
 	var networkInterfaces []*compute.NetworkInterface
@@ -209,7 +203,7 @@ func (i GoogleInstanceService) createNetworkInterfacesParams(networks Networks, 
 	}
 
 	networkInterface := &compute.NetworkInterface{
-		Network:       network.SelfLink,
+		Network:       networkLink,
 		Subnetwork:    subnetworkLink,
 		AccessConfigs: accessConfigs,
 		NetworkIP:     networks.StaticPrivateIP(),

--- a/src/bosh-google-cpi/google/subnetwork_service/subnetwork.go
+++ b/src/bosh-google-cpi/google/subnetwork_service/subnetwork.go
@@ -3,4 +3,5 @@ package subnetwork
 type Subnetwork struct {
 	Name     string
 	SelfLink string
+	Network  string
 }


### PR DESCRIPTION
this bypasses looking up network as subnetwork api call will return network link