### PR TITLE
Create stemcell images with MULTI_IP_SUBNET guest os feature

### DIFF
--- a/src/bosh-google-cpi/google/image_service/google_image_service_create.go
+++ b/src/bosh-google-cpi/google/image_service/google_image_service_create.go
@@ -102,6 +102,9 @@ func (i GoogleImageService) create(name string, description string, sourceURL st
 		Name:        name,
 		Description: description,
 		RawDisk:     rawdisk,
+		GuestOsFeatures: []*compute.GuestOsFeature{
+			{ Type: "MULTI_IP_SUBNET" },
+		},
 	}
 
 	i.logger.Debug(googleImageServiceLogTag, "Creating Google Image with params: %#v", image)


### PR DESCRIPTION
This change updates create_stemcell to use the MULTI_IP_SUBNET guest os feature when creating the google cloud image. This allows the instance to use a different netmask then the /32 that is enforced by google cloud. See https://cloud.google.com/vpc/docs/create-use-multiple-interfaces for more details.

This improves the resilience of network diffing for the BOSH director and prevents unnecessary recreates. Specifically, there are times in which the BOSH director will save the network settings as reported by the agent in the database. Due to the fact that the agent on google cloud reports a /32 netmask, the BOSH director will detect a network change on the next deploy when it computes the expected netmask from the manual network's CIDR. This will cause a recreation of the VM. With this change, this should no longer happen.

[#166359647](https://www.pivotaltracker.com/story/show/166359647)

@evandbrown I've tested this change and it seems to work fine for our example deployments, but I'm somewhat unsure of the complete side effects of using `MULTI_IP_SUBNET` are. Do you think this change seems reasonable for the Google CPI moving forward? 

If this change is acceptible, this also means that we may have to refine the light stemcell building process to do the same.

Let me know what you think,

@jfmyers9