### PR TITLE
Remove the usage of hardcoded mincpuplatform values

### DIFF
--- a/src/bosh-google-cpi/google/instance_service/google_instance_service_create.go
+++ b/src/bosh-google-cpi/google/instance_service/google_instance_service_create.go
@@ -84,7 +84,8 @@ func (i GoogleInstanceService) Create(vmProps *Properties, networks Networks, re
 		Labels:            vmProps.Labels,
 		GuestAccelerators: acceleratorParams,
 		// Specify a non-Sandy Bridge CPU for known zones defined in the minCpuPlatform map
-		MinCpuPlatform: minCpuPlatform[vmProps.Zone],
+		// MinCpuPlatform: minCpuPlatform[vmProps.Zone],
+		MinCpuPlatform: "",
 	}
 
 	i.logger.Debug(googleInstanceServiceLogTag, "Creating Google Instance with params: %v", vm)

--- a/src/bosh-google-cpi/google/instance_service/google_instance_service_create.go
+++ b/src/bosh-google-cpi/google/instance_service/google_instance_service_create.go
@@ -19,16 +19,6 @@ const defaultRootDiskSizeGb = 10
 const userDataKey = "user_data"
 const nodeGroupNodeAffinityKey = "compute.googleapis.com/node-group-name"
 
-// The zones in this map are known to default to Sandy Bridge CPUs, which do
-// not expose RDRAND required to seed sufficient entropy to avoid the bosh-agent
-// blocking on boot. We can specify an Intel Broadwell platform to avoid Sandy
-// Bridge.
-// TODO(evanbrown): Allow MinCpuPlatform to be configured in cloud_properties.
-var minCpuPlatform = map[string]string{
-	"us-central1-a":  "Intel Broadwell",
-	"europe-west1-b": "Intel Broadwell",
-}
-
 func (i GoogleInstanceService) Create(vmProps *Properties, networks Networks, registryEndpoint string) (string, error) {
 	uuidStr, err := i.uuidGen.Generate()
 	if err != nil {
@@ -83,9 +73,7 @@ func (i GoogleInstanceService) Create(vmProps *Properties, networks Networks, re
 		Tags:              &tags,
 		Labels:            vmProps.Labels,
 		GuestAccelerators: acceleratorParams,
-		// Specify a non-Sandy Bridge CPU for known zones defined in the minCpuPlatform map
-		// MinCpuPlatform: minCpuPlatform[vmProps.Zone],
-		MinCpuPlatform: "",
+		MinCpuPlatform:    "",
 	}
 
 	i.logger.Debug(googleInstanceServiceLogTag, "Creating Google Instance with params: %v", vm)

--- a/src/bosh-google-cpi/integration/vm_test.go
+++ b/src/bosh-google-cpi/integration/vm_test.go
@@ -285,6 +285,11 @@ var _ = Describe("VM", func() {
 		assertSucceeds(request)
 	})
 
+	// us-central1-a and europe-west1-b were known to default to Sandy Bridge CPUs, 
+	// which do not expose RDRAND required to seed sufficient entropy to avoid the 
+	// bosh-agent blocking on boot. This is not an issue anymore (n1 defaults to 
+	// Broadwell), but we're keeping the tests to ensure the behaviour is what 
+	// we expect.
 	It("can create a VM in us-central1-a and not get a Sandy Bridge CPU", func() {
 		By("creating a VM")
 		var vmCID string

--- a/src/bosh-google-cpi/integration/vm_test.go
+++ b/src/bosh-google-cpi/integration/vm_test.go
@@ -290,7 +290,7 @@ var _ = Describe("VM", func() {
 	// bosh-agent blocking on boot. This is not an issue anymore (n1 defaults to 
 	// Broadwell), but we're keeping the tests to ensure the behaviour is what 
 	// we expect.
-	It("can create a VM in us-central1-a and not get a Sandy Bridge CPU", func() {
+	It("can create a VM in us-central1-a and not get a Sandy Bridge CPU when creating n1 VMs (Sandy Bridge is blocking bosh-agent on boot)", func() {
 		By("creating a VM")
 		var vmCID string
 		request := fmt.Sprintf(`{
@@ -329,7 +329,7 @@ var _ = Describe("VM", func() {
 		assertSucceeds(request)
 	})
 
-	It("can create a VM in europe-west1-b and not get a Sandy Bridge CPU", func() {
+	It("can create a VM in europe-west1-b and not get a Sandy Bridge CPU when creating n1 VMs (Sandy Bridge is blocking bosh-agent on boot)", func() {
 		By("creating a VM")
 		var vmCID string
 		request := fmt.Sprintf(`{


### PR DESCRIPTION
I would like to no longer pass mincpuplatform in the call to create a VM. This is causing issues when CPI is asked to create gen2 VM (n2) in any of the following zones: us-central1-a and europe-west1-b. Here is the error, returned by the google API:

`googleapi: Error 400: The selected machine type (n2-custom-2-4096) has a required CPU platform of cascadelake. The minimum CPU platform must match this, but was broadwell.`

The need for having the map minCpuPlatform, that specifies min CPU platform "Intel Broadwell" for zones us-central1-a and europe-west1-b appears to be no longer valid. Based on the test, I've performed, the mincpuplatform in both zones now defaults to Intel Broadwell (not Sandy Bridge), when trying to create a gen1 VM.