### PR TITLE
Support E2, N2, etc custom VM sizes

### DIFF
--- a/src/bosh-google-cpi/action/cloud_properties.go
+++ b/src/bosh-google-cpi/action/cloud_properties.go
@@ -45,6 +45,7 @@ type VMCloudProperties struct {
 	MachineType         string           `json:"machine_type,omitempty"`
 	CPU                 int              `json:"cpu,omitempty"`
 	RAM                 int              `json:"ram,omitempty"`
+	MachineSeries       string           `json:"machine_series,omitempty"`
 	RootDiskSizeGb      int              `json:"root_disk_size_gb,omitempty"`
 	RootDiskType        string           `json:"root_disk_type,omitempty"`
 	AutomaticRestart    bool             `json:"automatic_restart,omitempty"`

--- a/src/bosh-google-cpi/action/create_vm.go
+++ b/src/bosh-google-cpi/action/create_vm.go
@@ -350,7 +350,7 @@ func (cv createVMBase) findMachineTypeLink(cloudProps VMCloudProperties, zone st
 			return "", bosherr.Error("Creating vm: 'machine_type' or 'cpu' and 'ram' must be provided")
 		}
 
-		machineTypeLink = cv.machineTypeService.CustomLink(cloudProps.CPU, cloudProps.RAM, zone)
+		machineTypeLink = cv.machineTypeService.CustomLink(cloudProps.CPU, cloudProps.RAM, zone, cloudProps.MachineSeries)
 	}
 
 	return machineTypeLink, nil

--- a/src/bosh-google-cpi/action/create_vm_v2_test.go
+++ b/src/bosh-google-cpi/action/create_vm_v2_test.go
@@ -363,6 +363,7 @@ var _ = Describe("CreateVM", func() {
 		Context("when custom machine type is set", func() {
 			BeforeEach(func() {
 				cloudProps.MachineType = ""
+				cloudProps.MachineSeries = "E2"
 				cloudProps.CPU = 2
 				cloudProps.RAM = 5120
 
@@ -377,6 +378,7 @@ var _ = Describe("CreateVM", func() {
 				Expect(imageService.FindCalled).To(BeTrue())
 				Expect(machineTypeService.FindCalled).To(BeFalse())
 				Expect(machineTypeService.CustomLinkCalled).To(BeTrue())
+				Expect(machineTypeService.CustomLinkMachineSeries).To(Equal("E2"))
 				Expect(diskTypeService.FindCalled).To(BeFalse())
 				Expect(vmService.CreateCalled).To(BeTrue())
 				Expect(vmService.CleanUpCalled).To(BeFalse())

--- a/src/bosh-google-cpi/google/machine_type_service/fakes/fake_machine_type_service.go
+++ b/src/bosh-google-cpi/google/machine_type_service/fakes/fake_machine_type_service.go
@@ -10,8 +10,9 @@ type FakeMachineTypeService struct {
 	FindMachineType machinetype.MachineType
 	FindErr         error
 
-	CustomLinkCalled bool
-	CustomLinkLink   string
+	CustomLinkCalled        bool
+	CustomLinkMachineSeries string
+	CustomLinkLink          string
 }
 
 func (d *FakeMachineTypeService) Find(id string, zone string) (machinetype.MachineType, bool, error) {
@@ -19,7 +20,8 @@ func (d *FakeMachineTypeService) Find(id string, zone string) (machinetype.Machi
 	return d.FindMachineType, d.FindFound, d.FindErr
 }
 
-func (d *FakeMachineTypeService) CustomLink(cpu int, ram int, zone string) string {
+func (d *FakeMachineTypeService) CustomLink(cpu int, ram int, zone string, machineSeries string) string {
 	d.CustomLinkCalled = true
+	d.CustomLinkMachineSeries = machineSeries
 	return d.CustomLinkLink
 }

--- a/src/bosh-google-cpi/google/machine_type_service/google_machine_type_service_custom_link.go
+++ b/src/bosh-google-cpi/google/machine_type_service/google_machine_type_service_custom_link.go
@@ -1,16 +1,20 @@
 package machinetype
 
 import (
-	"fmt"
-
 	"bosh-google-cpi/util"
+	"fmt"
+	"strings"
 )
 
-func (m GoogleMachineTypeService) CustomLink(cpu int, ram int, zone string) string {
+func (m GoogleMachineTypeService) CustomLink(cpu int, ram int, zone string, machineSeries string) string {
 	suffix := ""
+	prefix := ""
 	extendedThreshold := int(float64(cpu*1024) * 6.5)
 	if ram > extendedThreshold {
 		suffix = "-ext"
 	}
-	return fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/machineTypes/custom-%d-%d%s", m.project, util.ResourceSplitter(zone), cpu, ram, suffix)
+	if machineSeries != "" && strings.ToLower(machineSeries) != "n1" {
+		prefix = fmt.Sprintf("%s-", strings.ToLower(machineSeries))
+	}
+	return fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/machineTypes/%scustom-%d-%d%s", m.project, util.ResourceSplitter(zone), prefix, cpu, ram, suffix)
 }

--- a/src/bosh-google-cpi/google/machine_type_service/google_machine_type_service_custom_link_test.go
+++ b/src/bosh-google-cpi/google/machine_type_service/google_machine_type_service_custom_link_test.go
@@ -14,11 +14,19 @@ var _ = Describe("GoogleMachineTypeServiceCustomLink", func() {
 		subject = NewGoogleMachineTypeService("foo", nil, nil)
 	})
 
-	It("provides a normal sized machine type link", func() {
-		Expect(subject.CustomLink(2, 2048, "us-east1-d")).To(Equal("https://www.googleapis.com/compute/v1/projects/foo/zones/us-east1-d/machineTypes/custom-2-2048"))
+	It("provides a default N1 sized machine type link", func() {
+		Expect(subject.CustomLink(2, 2048, "us-east1-d", "")).To(Equal("https://www.googleapis.com/compute/v1/projects/foo/zones/us-east1-d/machineTypes/custom-2-2048"))
+	})
+
+	It("provides a explict N1 sized machine type link", func() {
+		Expect(subject.CustomLink(2, 2048, "us-east1-d", "N1")).To(Equal("https://www.googleapis.com/compute/v1/projects/foo/zones/us-east1-d/machineTypes/custom-2-2048"))
+	})
+
+	It("provides a normal E2 sized machine type link", func() {
+		Expect(subject.CustomLink(2, 2048, "us-east1-d", "E2")).To(Equal("https://www.googleapis.com/compute/v1/projects/foo/zones/us-east1-d/machineTypes/e2-custom-2-2048"))
 	})
 
 	It("provides an extended machine type link", func() {
-		Expect(subject.CustomLink(4, 26880, "us-east1-d")).To(Equal("https://www.googleapis.com/compute/v1/projects/foo/zones/us-east1-d/machineTypes/custom-4-26880-ext"))
+		Expect(subject.CustomLink(4, 26880, "us-east1-d", "")).To(Equal("https://www.googleapis.com/compute/v1/projects/foo/zones/us-east1-d/machineTypes/custom-4-26880-ext"))
 	})
 })

--- a/src/bosh-google-cpi/google/machine_type_service/machine_type_service.go
+++ b/src/bosh-google-cpi/google/machine_type_service/machine_type_service.go
@@ -2,5 +2,5 @@ package machinetype
 
 type Service interface {
 	Find(id string, zone string) (MachineType, bool, error)
-	CustomLink(cpu int, ram int, zone string) string
+	CustomLink(cpu int, ram int, zone string, machineSeries string) string
 }


### PR DESCRIPTION
The N1 VM sizes had no prefix, such as custom-2-4096. Starting with N2
and E2, they add the machine class in the VM name like e2-custom-2-4096.

Signed-off-by: David Stevenson <stevensonda@vmware.com>