### PR TITLE
Remove blobstore info from IaaS metadata endpoints

### DIFF
--- a/jobs/google_cpi/spec
+++ b/jobs/google_cpi/spec
@@ -28,53 +28,6 @@ properties:
     description: "The name of the default Google Compute Engine Disk Type the CPI will use when creating the instances root disk"
     default: ""
 
-  blobstore.provider:
-    description: Provider of the blobstore used by director and agent (dav|simple|s3|gcs)
-    default: 'dav'
-  blobstore.bucket_name:
-    description: AWS S3 or GCP GCS Bucket used by external blobstore plugin
-  blobstore.credentials_source:
-    description: AWS or GCP Credential Source (static / env_or_profile / none)
-    default: 'static'
-  blobstore.access_key_id:
-    description: AWS access_key_id used by s3 blobstore plugin (Required when blobstore.credentials_source is set to `static`)
-    default: null
-  blobstore.secret_access_key:
-    description: AWS secret_access_key used by s3 blobstore plugin (Required when blobstore.credentials_source is set to `static`)
-    default: null
-  blobstore.json_key:
-    description: Contents of a GCP JSON service account file used for static credentials_source (optional)
-  blobstore.s3_region:
-    description: AWS region used by s3 blobstore plugin (Required when blobstore.credentials_source is set to `static`)
-  blobstore.use_ssl:
-    description: Whether the s3 blobstore plugin should use SSL to connect to the blobstore server
-    default: true
-  blobstore.s3_port:
-    description: Port of blobstore server used by s3 blobstore plugin
-    default: 443
-  blobstore.host:
-    description: Host of blobstore server used by s3 blobstore plugin
-  blobstore.ssl_verify_peer:
-    description: Whether the s3 blobstore plugin should verify its peer when using SSL
-  blobstore.s3_signature_version:
-    description: Signature version used to connect to an s3 blobstore
-  blobstore.storage_class:
-    description: Storage Class used when storing blobs in GCS (optional, if not provided uses bucket default)
-  blobstore.encryption_key:
-    description: Customer-Supplied Encryption key used when storing blobs in GCS (Optional - Base64 encoded 32 byte key)
-
-  blobstore.path:
-    description: local blobstore path
-  blobstore.address:
-    description: Address of blobstore server used by simple blobstore plugin
-  blobstore.port:
-    description: Port of blobstore server used by simple blobstore plugin
-    default: 25250
-  blobstore.agent.user:
-    description: Username agent uses to connect to blobstore used by dav blobstore plugin (Optional)
-  blobstore.agent.password:
-    description: Password agent uses to connect to blobstore used by dav blobstore plugin (Required only when user is provided)
-    
   ntp:
     description: List of ntp server IPs
     default:
@@ -82,33 +35,6 @@ properties:
 
   agent.mbus:
     description: "Mbus URL used by deployed BOSH agents"
-  agent.blobstore.credentials_source:
-    description: AWS or GCP Credential Source (static / env_or_profile / none)
-    default: 'static'
-  agent.blobstore.access_key_id:
-    description: AWS access_key_id for agent used by s3 blobstore plugin (Required when blobstore.credentials_source is set to `static`)
-  agent.blobstore.secret_access_key:
-    description: AWS secret_access_key for agent used by s3 blobstore plugin (Required when blobstore.credentials_source is set to `static`)
-  agent.blobstore.json_key:
-    description: Contents of a GCP JSON service account file used for static credentials_source (optional)
-  agent.blobstore.s3_region:
-    description: AWS region for agent used by s3 blobstore plugin (Required when blobstore.credentials_source is set to `static`)
-  agent.blobstore.address:
-    description: Address for agent to connect to blobstore server used by dav blobstore plugin
-  agent.blobstore.use_ssl:
-    description: Whether the agent blobstore plugin should use SSL to connect to the blobstore server
-  agent.blobstore.s3_port:
-    description: Port of agent blobstore server used by s3 blobstore plugin
-  agent.blobstore.host:
-    description: Host of agent blobstore server used by s3 blobstore plugin
-  agent.blobstore.ssl_verify_peer:
-    description: Whether the agent blobstore plugin should verify its peer when using SSL
-  agent.blobstore.s3_signature_version:
-    description: Signature version used to connect to an s3 blobstore
-  agent.blobstore.storage_class:
-    description: Storage Class used when storing blobs in GCS (optional, if not provided uses bucket default)
-  agent.blobstore.encryption_key:
-    description: Customer-Supplied Encryption key used when storing blobs in GCS (Optional - Base64 encoded 32 byte key)
 
   registry.use_gce_metadata:
     description: "Google Compute Engine metadata should be used instead of BOSH registry"

--- a/jobs/google_cpi/templates/config/cpi.json.erb
+++ b/jobs/google_cpi/templates/config/cpi.json.erb
@@ -39,59 +39,6 @@ end
 
 agent_params = params["cloud"]["properties"]["agent"]
 
-if_p('blobstore') do
-  agent_params["blobstore"] = {
-       "provider" => p('blobstore.provider'),
-       "options" => {}
-  }
-
-  blobstore = agent_params["blobstore"]
-
-  if p('blobstore.provider') == "s3"
-    blobstore["options"] = {
-      "bucket_name" => p('blobstore.bucket_name'),
-      "credentials_source" => p(['agent.blobstore.credentials_source', 'blobstore.credentials_source']),
-      "access_key_id" => p(['agent.blobstore.access_key_id', 'blobstore.access_key_id'], nil),
-      "secret_access_key" => p(['agent.blobstore.secret_access_key', 'blobstore.secret_access_key'], nil),
-    }
-    def update_blobstore_options(blobstore, manifest_key, rendered_key=manifest_key)
-      value = p(["agent.blobstore.#{manifest_key}", "blobstore.#{manifest_key}"], nil)
-      blobstore["options"][rendered_key] = value unless value.nil?
-    end
-    update_blobstore_options(blobstore, 'use_ssl')
-    update_blobstore_options(blobstore, 's3_port', 'port')
-    update_blobstore_options(blobstore, 'host')
-    update_blobstore_options(blobstore, 'ssl_verify_peer')
-    update_blobstore_options(blobstore, 's3_signature_version', 'signature_version')
-    update_blobstore_options(blobstore, 's3_region', 'region')
-  elsif p('blobstore.provider') == "gcs"
-    blobstore["options"] = {
-      "bucket_name" => p('blobstore.bucket_name'),
-      "credentials_source" => p(['agent.blobstore.credentials_source', 'blobstore.credentials_source']),
-      "json_key" => p(['agent.blobstore.json_key', 'blobstore.json_key'], nil),
-    }
-    def update_blobstore_options(blobstore, manifest_key, rendered_key=manifest_key)
-      value = p(["agent.blobstore.#{manifest_key}", "blobstore.#{manifest_key}"], nil)
-      blobstore["options"][rendered_key] = value unless value.nil?
-    end
-    update_blobstore_options(blobstore, 'storage_class')
-    update_blobstore_options(blobstore, 'encryption_key')
-  elsif p('blobstore.provider') == 'local'
-    blobstore["options"] = {
-      "blobstore_path" => p('blobstore.path')
-    }
-  else
-    blobstore["options"] = {
-      "endpoint" => "http://#{p(['agent.blobstore.address', 'blobstore.address'])}:#{p('blobstore.port')}"
-    }
-
-    if_p('blobstore.agent.user') do
-      blobstore["options"]["user"] = p('blobstore.agent.user')
-      blobstore["options"]["password"] = p('blobstore.agent.password')
-    end
-  end
-end
-
 if_p('agent.mbus') do |mbus|
   agent_params["mbus"] = mbus
 end.else_if_p('nats') do

--- a/spec/jobs/cpi.json.erb_spec.rb
+++ b/spec/jobs/cpi.json.erb_spec.rb
@@ -15,13 +15,6 @@ describe 'google_cpi job' do
       {
         'google' => {
           'project' => 'some_google_project'
-        },
-        'blobstore' => {
-          'address' => 'blobstore-address.example.com',
-          'agent' => {
-            'user' => 'agent',
-            'password' => 'agent-password'
-          }
         }
       }
     end
@@ -30,27 +23,6 @@ describe 'google_cpi job' do
 
     it 'renders the CPI config properly' do
       expect(rendered_google_properties['project']).to eq('some_google_project')
-    end
-
-    context 'when using a dav blobstore' do
-      let(:rendered_blobstore) { config['cloud']['properties']['agent']['blobstore'] }
-
-      it 'renders agent user/password for accessing blobstore' do
-          expect(rendered_blobstore['options']['user']).to eq('agent')
-          expect(rendered_blobstore['options']['password']).to eq('agent-password')
-      end
-
-      context 'when enabling signed URLs' do
-        before do
-          manifest_properties['blobstore']['agent'].delete('user')
-          manifest_properties['blobstore']['agent'].delete('password')
-        end
-
-        it 'does not render agent user/password for accessing blobstore' do
-          expect(rendered_blobstore['options']['user']).to be_nil
-          expect(rendered_blobstore['options']['password']).to be_nil
-        end
-      end
     end
   end
 end

--- a/src/bosh-google-cpi/README.md
+++ b/src/bosh-google-cpi/README.md
@@ -32,12 +32,7 @@ Create a configuration file:
         "mbus": "https:\/\/mbus:mbus@0.0.0.0:6868",
         "ntp": [
           "169.254.169.254"
-        ],
-        "blobstore": {
-          "provider": "local",
-          "options": {
-          }
-        }
+        ]
       },
       "registry": {
         "use_gce_metadata": true
@@ -56,8 +51,6 @@ Create a configuration file:
 | google.default_root_disk_type             | N          | String        | The name of the default [Google Compute Engine Disk Type](https://cloud.google.com/compute/docs/disks/#overview) the CPI will use when creating the instance root disk
 | actions.agent.mbus.endpoint               | Y          | String        | [BOSH Message Bus](http://bosh.io/docs/bosh-components.html#nats) URL used by deployed BOSH agents
 | actions.agent.ntp                         | Y          | Array&lt;String&gt; | List of NTP servers used by deployed BOSH agents
-| actions.agent.blobstore.type              | Y          | String        | Provider type for the [BOSH Blobstore](http://bosh.io/docs/bosh-components.html#blobstore) used by deployed BOSH agents (e.g. dav, s3)
-| actions.agent.blobstore.options           | Y          | Hash          | Options for the [BOSH Blobstore](http://bosh.io/docs/bosh-components.html#blobstore) used by deployed BOSH agents
 | actions.registry.protocol                 | Y          | String        | [BOSH Registry](http://bosh.io/docs/bosh-components.html#registry) Protocol (`http` or `https`)
 | actions.registry.host                     | Y          | String        | [BOSH Registry](http://bosh.io/docs/bosh-components.html#registry) Host
 | actions.registry.port                     | Y          | Integer       | [BOSH Registry](http://bosh.io/docs/bosh-components.html#registry) port

--- a/src/bosh-google-cpi/action/concrete_factory_options_test.go
+++ b/src/bosh-google-cpi/action/concrete_factory_options_test.go
@@ -17,9 +17,6 @@ var _ = Describe("ConcreteFactoryOptions", func() {
 			Agent: registry.AgentOptions{
 				Mbus: "fake-mbus",
 				Ntp:  []string{},
-				Blobstore: registry.BlobstoreOptions{
-					Provider: "fake-blobstore-type",
-				},
 			},
 			Registry: registry.ClientOptions{
 				Protocol: "http",

--- a/src/bosh-google-cpi/action/create_vm_v1_test.go
+++ b/src/bosh-google-cpi/action/create_vm_v1_test.go
@@ -69,9 +69,6 @@ var _ = Describe("CreateVM", func() {
 		}
 		agentOptions = registry.AgentOptions{
 			Mbus: "http://fake-mbus",
-			Blobstore: registry.BlobstoreOptions{
-				Provider: "fake-blobstore-type",
-			},
 		}
 		defaultRootDiskSizeGb = 0
 		defaultRootDiskType = ""
@@ -151,9 +148,6 @@ var _ = Describe("CreateVM", func() {
 
 			expectedAgentSettings = registry.AgentSettings{
 				AgentID: "fake-agent-id",
-				Blobstore: registry.BlobstoreSettings{
-					Provider: "fake-blobstore-type",
-				},
 				Disks: registry.DisksSettings{
 					System:     "/dev/sda",
 					Persistent: map[string]registry.PersistentSettings{},

--- a/src/bosh-google-cpi/action/create_vm_v2_test.go
+++ b/src/bosh-google-cpi/action/create_vm_v2_test.go
@@ -69,9 +69,6 @@ var _ = Describe("CreateVM", func() {
 		}
 		agentOptions = registry.AgentOptions{
 			Mbus: "http://fake-mbus",
-			Blobstore: registry.BlobstoreOptions{
-				Provider: "fake-blobstore-type",
-			},
 		}
 		defaultRootDiskSizeGb = 0
 		defaultRootDiskType = ""
@@ -151,9 +148,6 @@ var _ = Describe("CreateVM", func() {
 
 			expectedAgentSettings = registry.AgentSettings{
 				AgentID: "fake-agent-id",
-				Blobstore: registry.BlobstoreSettings{
-					Provider: "fake-blobstore-type",
-				},
 				Disks: registry.DisksSettings{
 					System:     "/dev/sda",
 					Persistent: map[string]registry.PersistentSettings{},

--- a/src/bosh-google-cpi/config/config_test.go
+++ b/src/bosh-google-cpi/config/config_test.go
@@ -20,9 +20,6 @@ var validGoogleConfig = bgcconfig.Config{
 var validAgentOptions = registry.AgentOptions{
 	Mbus: "fake-mbus",
 	Ntp:  []string{},
-	Blobstore: registry.BlobstoreOptions{
-		Provider: "fake-blobstore-type",
-	},
 }
 
 var validRegistryOptions = registry.ClientOptions{

--- a/src/bosh-google-cpi/integration/config.go
+++ b/src/bosh-google-cpi/integration/config.go
@@ -57,10 +57,7 @@ var (
 			"project": "%v"
 		  },
 		  "agent": {
-			"mbus": "http://127.0.0.1",
-			"blobstore": {
-			  "provider": "local"
-			}
+				"mbus": "http://127.0.0.1"
 		  },
 		  "registry": {
 			"use_gce_metadata": true

--- a/src/bosh-google-cpi/registry/agent_options.go
+++ b/src/bosh-google-cpi/registry/agent_options.go
@@ -11,38 +11,12 @@ type AgentOptions struct {
 
 	// List of NTP servers
 	Ntp []string
-
-	// Blobstore options
-	Blobstore BlobstoreOptions
-}
-
-// BlobstoreOptions are the blobstore options passed to the BOSH Agent (http://bosh.io/docs/bosh-components.html#agent).
-type BlobstoreOptions struct {
-	// Blobstore provider
-	Provider string
-
-	// Blobstore options
-	Options map[string]interface{}
 }
 
 // Validate validates the Agent options.
 func (o AgentOptions) Validate() error {
 	if o.Mbus == "" {
 		return bosherr.Error("Must provide a non-empty Mbus")
-	}
-
-	err := o.Blobstore.Validate()
-	if err != nil {
-		return bosherr.WrapError(err, "Validating Blobstore configuration")
-	}
-
-	return nil
-}
-
-// Validate validates the Blobstore options.
-func (o BlobstoreOptions) Validate() error {
-	if o.Provider == "" {
-		return bosherr.Error("Must provide non-empty Type")
 	}
 
 	return nil

--- a/src/bosh-google-cpi/registry/agent_settings.go
+++ b/src/bosh-google-cpi/registry/agent_settings.go
@@ -7,9 +7,6 @@ type AgentSettings struct {
 	// Agent ID
 	AgentID string `json:"agent_id"`
 
-	// Blobstore settings
-	Blobstore BlobstoreSettings `json:"blobstore"`
-
 	// Disks settings
 	Disks DisksSettings `json:"disks"`
 
@@ -27,15 +24,6 @@ type AgentSettings struct {
 
 	// VM settings
 	VM VMSettings `json:"vm"`
-}
-
-// BlobstoreSettings are the Blobstore settings for a particular VM.
-type BlobstoreSettings struct {
-	// Blobstore provider
-	Provider string `json:"provider"`
-
-	// Blobstore options
-	Options map[string]interface{} `json:"options"`
 }
 
 // DisksSettings are the Disks settings for a particular VM.
@@ -111,10 +99,6 @@ func NewAgentSettings(agentID string, vmCID string, networksSettings NetworksSet
 		Disks: DisksSettings{
 			System:     defaultSystemDisk,
 			Persistent: map[string]PersistentSettings{},
-		},
-		Blobstore: BlobstoreSettings{
-			Provider: agentOptions.Blobstore.Provider,
-			Options:  agentOptions.Blobstore.Options,
 		},
 		Env:      EnvSettings(env),
 		Mbus:     agentOptions.Mbus,


### PR DESCRIPTION
The BOSH agent reads its blobstore settings from the metadata API endpoint (or equivalent) for its VM within the IaaS. If the blobstore settings are not set in the `env.bosh.blobstores` property, it will fallback to the top-level `blobstore` property in the metadata.

However, in modern configurations, the Director always sends the blobstore settings as part of the environment hash. Additionally, the Director does redaction of credentials in the environment hash when the signed URLs blobstore feature is enabled. This redaction is not applied to the top-level `blobstore` property in the metadata because that is generated solely by the CPI.

Rather than updating each CPI to know about the signed URL feature, we are instead removing the `blobstore` properties from the CPI. This will ensure that Director is the sole point of contact when configuring agent blobstore settings, and ensure that they are always properly redacted.