### PR TITLE
Redact more secrets from logs

### DIFF
--- a/src/bosh-google-cpi/api/dispatcher/json.go
+++ b/src/bosh-google-cpi/api/dispatcher/json.go
@@ -5,11 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"regexp"
 
 	bgcaction "bosh-google-cpi/action"
 	bgcapi "bosh-google-cpi/api"
 	"bosh-google-cpi/constant"
+	"bosh-google-cpi/redactor"
 )
 
 const (
@@ -67,7 +67,7 @@ func NewJSON(
 func (c JSON) Dispatch(reqBytes []byte) []byte {
 	var req Request
 
-	c.logger.DebugWithDetails(jsonLogTag, "Request bytes", redactSecrets(string(reqBytes)))
+	c.logger.DebugWithDetails(jsonLogTag, "Request bytes", redactor.RedactSecrets(string(reqBytes)))
 
 	decoder := json.NewDecoder(bytes.NewReader(reqBytes))
 	decoder.UseNumber()
@@ -109,14 +109,9 @@ func (c JSON) Dispatch(reqBytes []byte) []byte {
 		return c.buildCpiError("Failed to serialize result")
 	}
 
-	c.logger.DebugWithDetails(jsonLogTag, "Response bytes", string(respBytes))
+	c.logger.DebugWithDetails(jsonLogTag, "Response bytes", redactor.RedactSecrets(string(respBytes)))
 
 	return respBytes
-}
-
-func redactSecrets(sourceString string) string {
-	re := regexp.MustCompile(`(?si)("account_key"|"json_key"|"password"|"private_key"|"secret_access_key"): ?".*?"`)
-	return re.ReplaceAllString(sourceString, `$1:"REDACTED"`)
 }
 
 func (c JSON) buildCloudError(err error) []byte {
@@ -144,7 +139,7 @@ func (c JSON) buildCloudError(err error) []byte {
 		panic(err)
 	}
 
-	c.logger.DebugWithDetails(jsonLogTag, "CloudError response bytes", string(respErrBytes))
+	c.logger.DebugWithDetails(jsonLogTag, "CloudError response bytes", redactor.RedactSecrets(string(respErrBytes)))
 
 	return respErrBytes
 }
@@ -163,7 +158,7 @@ func (c JSON) buildCpiError(message string) []byte {
 		panic(err)
 	}
 
-	c.logger.DebugWithDetails(jsonLogTag, "CpiError response bytes", string(respErrBytes))
+	c.logger.DebugWithDetails(jsonLogTag, "CpiError response bytes", redactor.RedactSecrets(string(respErrBytes)))
 
 	return respErrBytes
 }
@@ -182,7 +177,7 @@ func (c JSON) buildNotImplementedError() []byte {
 		panic(err)
 	}
 
-	c.logger.DebugWithDetails(jsonLogTag, "NotImplementedError response bytes", string(respErrBytes))
+	c.logger.DebugWithDetails(jsonLogTag, "NotImplementedError response bytes", redactor.RedactSecrets(string(respErrBytes)))
 
 	return respErrBytes
 }

--- a/src/bosh-google-cpi/api/dispatcher/json_test.go
+++ b/src/bosh-google-cpi/api/dispatcher/json_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -89,7 +90,21 @@ var _ = Describe("JSON", func() {
 							logBuffer.Write([]byte(fmt.Sprintf("%s", args...)))
 						}
 
-						dispatcher.Dispatch([]byte(`{"method":"fake-action","arguments":[{"Password": "secret_data", "private_key":"more\n_secret_data","public_key":"public_data","account_key":"secret_data","json_key":"secret_data","secret_access_key":"secret_data"}]}`))
+						respBytes := dispatcher.Dispatch([]byte(`{
+  "method": "fake-action",
+  "arguments": [
+    {
+      "Password": "secret_data",
+      "private_key": "more\n_secret_data",
+      "public_key": "public_data",
+      "account_key": "secret_data",
+      "json_key": "secret_data",
+      "secret_access_key": "secret_data"
+    }
+  ]
+}`))
+						Expect(respBytes).NotTo(ContainSubstring("Bosh::Clouds::CpiError"))
+
 						_, msg, args := logger.DebugWithDetailsArgsForCall(0)
 						Expect(msg).To(Equal("Request bytes"))
 						Expect(args).To(HaveLen(1))

--- a/src/bosh-google-cpi/redactor/redactor.go
+++ b/src/bosh-google-cpi/redactor/redactor.go
@@ -1,0 +1,8 @@
+package redactor
+
+import "regexp"
+
+func RedactSecrets(sourceString string) string {
+	re := regexp.MustCompile(`(?si)\\*"(account_key|json_key|password|private_key|secret_access_key)\\*"\\*: ?\\*".*?\\*"`)
+	return re.ReplaceAllString(sourceString, `$1:"REDACTED"`)
+}

--- a/src/bosh-google-cpi/redactor/redactor_suite_test.go
+++ b/src/bosh-google-cpi/redactor/redactor_suite_test.go
@@ -1,0 +1,13 @@
+package redactor_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestDispatcher(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Redactor Suite")
+}

--- a/src/bosh-google-cpi/redactor/redactor_test.go
+++ b/src/bosh-google-cpi/redactor/redactor_test.go
@@ -1,0 +1,30 @@
+package redactor_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"bosh-google-cpi/redactor"
+)
+
+var _ = Describe("Redactor", func() {
+	Describe("RedactSecrets", func() {
+		It("Redacts", func() {
+			secretString := `{
+  "method": "fake-action",
+  "arguments": [
+    {
+      "Password": "secret_data",
+      "private_key": "more\n_secret_data",
+      "public_key": "public_data",
+      "account_key": "secret_data",
+      "json_key": "secret_data",
+      "secret_access_key": "secret_data"
+    }
+  ],
+  "context": "with agent settings \"{\\\"env\\\":{\\\"bosh\\\":{\\\"blobstores\\\":[{\\\"options\\\":{\\\"Password\\\": \\\"escaped_secret_data\\\",\\\"private_key\\\": \\\"escaped_more\n_secret_data\\\",\\\"public_key\\\": \\\"escaped_public_data\\\",\\\"account_key\\\": \\\"escaped_secret_data\\\",\\\"json_key\\\": \\\"escaped_secret_data\\\",\\\"secret_access_key\\\": \\\"escaped_secret_data\\\""
+}`
+			Expect(redactor.RedactSecrets(secretString)).NotTo(ContainSubstring("secret_data"))
+		})
+	})
+})


### PR DESCRIPTION
After  the work completed in https://github.com/cloudfoundry/bosh-google-cpi-release/pull/342, we found that there were still spots in the logs where secrets were printed:
- Updating VM metadata
- Printing request bytes in the response logging

This commit:
- extracts the redaction logic so it can be used in both places
- expands the redaction regex to handle arbitrary json escaping
- redacts in every conceivable logger call that could be logging secrets.