### PR TITLE
Detect platform during packaging to use the correct golang version

### DIFF
--- a/packages/bosh-google-cpi/packaging
+++ b/packages/bosh-google-cpi/packaging
@@ -1,9 +1,10 @@
 set -ex
 
+platform=`uname | tr '[:upper:]' '[:lower:]'`
 if [ -z "$BOSH_PACKAGES_DIR" ]; then
-	pkg_dir=$(readlink -nf /var/vcap/packages/golang-1-linux)
+	pkg_dir=$(readlink -nf /var/vcap/packages/golang-1-${platform})
 else
-	pkg_dir=$BOSH_PACKAGES_DIR/golang-1-linux
+	pkg_dir=$BOSH_PACKAGES_DIR/golang-1-${platform}
 fi
 
 source ${pkg_dir}/bosh/compile.env


### PR DESCRIPTION
Fixes Issue [#344](https://github.com/cloudfoundry/bosh-google-cpi-release/issues/344)