### PR TITLE
Update minimal and integration permissions

### DIFF
--- a/docs/bosh-director-role.yml
+++ b/docs/bosh-director-role.yml
@@ -19,6 +19,7 @@ included_permissions:
 - compute.disks.list
 - compute.disks.get
 - compute.disks.createSnapshot
+- compute.disks.resize
 - compute.snapshots.create
 - compute.disks.create
 - compute.images.useReadOnly
@@ -53,6 +54,7 @@ included_permissions:
 - compute.instances.deleteAccessConfig
 - compute.instances.addAccessConfig
 - compute.addresses.use
+- compute.addresses.useInternal
 
 # machine type
 - compute.machineTypes.get

--- a/src/bosh-google-cpi/integration/integration_suite_test.go
+++ b/src/bosh-google-cpi/integration/integration_suite_test.go
@@ -135,7 +135,21 @@ func validateMinimumPermissions() {
 
 	// permissions in addition to minimal set of permissions(docs/bosh-director-role.yml) required to run CPI
 	// these permissions are for testing specific use cases e.g. "create VM with an accelerator", "create a VM with a static private IP"
-	var additionalPermissionsForIntegrationTests = []string{"resourcemanager.projects.getIamPolicy", "iam.roles.get", "compute.disks.resize", "compute.addresses.useInternal", "compute.instances.setServiceAccount", "compute.acceleratorTypes.get"}
+	additionalPermissionsForIntegrationTests := []string{
+		// Permissions needed to check permissions for this test
+		"resourcemanager.projects.getIamPolicy",
+		"iam.roles.get",
+		// Permission needed when using accelerators property
+		"compute.acceleratorTypes.get",
+		// Permission needed when using service_account or service_scopes properties
+		"compute.instances.setServiceAccount",
+		// Permissions associated with the role iam.serviceAccountUser, needed when using the service_account or service_scopes properties.
+		"iam.serviceAccounts.actAs",
+		"iam.serviceAccounts.get",
+		"iam.serviceAccounts.list",
+		"resourcemanager.projects.get",
+		"resourcemanager.projects.list",
+	}
 
 	expectedPermissions = append(exampleRole.IncludedPermissions, additionalPermissionsForIntegrationTests...)
 


### PR DESCRIPTION
Disk resize and using private IPs need specific permissions, and are common use cases, so were added to the minimal permission doc.

Using service accounts for auth require a special set of permissions, as do using accelerators.

[#187935049]