### PR TITLE
Add sole-tenancy instance to clean up list

### DIFF
--- a/src/bosh-google-cpi/integration/vm_test.go
+++ b/src/bosh-google-cpi/integration/vm_test.go
@@ -712,6 +712,7 @@ var _ = Describe("VM", func() {
 				{
 				  "default": {
 					"type": "dynamic",
+					"tags": ["integration-delete"]
 					"cloud_properties": {
 					  "network_name": "%v"
 					}


### PR DESCRIPTION
The sole-tenancy instances are quite expensive, that is why we should make sure that they are not leaked.

There is a test which deletes the sole-tenancy instance but in case something fails the instance should be deleted in the clean up loop of the test suite. The "integration-delete" tag is set for that