### PR TITLE
Add permission for read-only access to snapshots

### DIFF
--- a/docs/bosh-director-role.yml
+++ b/docs/bosh-director-role.yml
@@ -74,6 +74,7 @@ included_permissions:
 # snapshots
 - compute.snapshots.delete
 - compute.snapshots.get
+- compute.snapshots.useReadOnly
 
 # target pool
 - compute.targetPools.list


### PR DESCRIPTION
Adds permissions to fix an error in the [`run-int` pipeline](https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-google-cpi/jobs/run-int/builds/106.1):

```
Updating disk 'disk-38cad309-c4ff-4705-6b4e-acfd95eda973': recreating from snapshot 'snapshot-a3e45257-75b8-4605-5c35-ef1f1e63d101': Failed to create Google Disk from snapshot: googleapi: Error 403: Required 'compute.snapshots.useReadOnly' permission for 'projects/cloud-foundry-310819/global/snapshots/snapshot-a3e45257-75b8-4605-5c35-ef1f1e63d101', forbidden
```

This change will need to be applied by someone with admin access to take effect.