### PR TITLE
Add fallback for permission errors

### DIFF
--- a/src/bosh-google-cpi/action/update_disk.go
+++ b/src/bosh-google-cpi/action/update_disk.go
@@ -1,6 +1,7 @@
 package action
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -109,6 +110,13 @@ func (ud UpdateDisk) Run(diskCID DiskCID, newSize int, cloudProps DiskCloudPrope
 	// is still intact and the caller can retry or fall back.
 	newDiskID, err := ud.diskService.CreateFromSnapshot(snap.SelfLink, sizeGib, diskTypeSelfLink, zone)
 	if err != nil {
+		if errors.Is(err, disk.ErrSnapshotPermissionDenied) {
+			return nil, api.NewInsufficientPermissionsError(
+				"Updating disk: the GCP service account is missing the compute.snapshots.useReadOnly permission " +
+					"required to create a disk from snapshot. Add the permission to enable native disk type changes, " +
+					"or the director will fall back to the copy-based update path.",
+			)
+		}
 		return nil, bosherr.WrapErrorf(err, "Updating disk '%s': recreating from snapshot '%s'", diskCID, snapshotID)
 	}
 

--- a/src/bosh-google-cpi/action/update_disk_test.go
+++ b/src/bosh-google-cpi/action/update_disk_test.go
@@ -234,6 +234,17 @@ var _ = Describe("UpdateDisk", func() {
 				Expect(snapshotService.DeleteCalled).To(BeTrue())
 			})
 
+			It("returns InsufficientPermissionsError and cleans up snapshot when CreateFromSnapshot is denied due to missing permission", func() {
+				diskService.CreateFromSnapshotErr = disk.ErrSnapshotPermissionDenied
+
+				_, err = updateDisk.Run("fake-disk-id", 10240, DiskCloudProperties{DiskType: "hyperdisk-balanced"})
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(BeAssignableToTypeOf(api.InsufficientPermissionsError{}))
+				Expect(err.Error()).To(ContainSubstring("compute.snapshots.useReadOnly"))
+				Expect(snapshotService.DeleteCalled).To(BeTrue())
+				Expect(diskService.DeleteCalled).To(BeFalse())
+			})
+
 			It("returns new disk CID with error if old disk deletion fails", func() {
 				diskService.DeleteErr = errors.New("fake-delete-error")
 

--- a/src/bosh-google-cpi/api/errors.go
+++ b/src/bosh-google-cpi/api/errors.go
@@ -21,6 +21,17 @@ type NotSupportedError struct{}
 func (e NotSupportedError) Type() string  { return "Bosh::Clouds::NotSupported" }
 func (e NotSupportedError) Error() string { return "Not supported" }
 
+type InsufficientPermissionsError struct {
+	message string
+}
+
+func NewInsufficientPermissionsError(message string) InsufficientPermissionsError {
+	return InsufficientPermissionsError{message: message}
+}
+
+func (e InsufficientPermissionsError) Type() string  { return "Bosh::Clouds::InsufficientPermissions" }
+func (e InsufficientPermissionsError) Error() string { return e.message }
+
 type VMNotFoundError struct {
 	vmID string
 }

--- a/src/bosh-google-cpi/google/disk/google_disk_service_create_from_snapshot.go
+++ b/src/bosh-google-cpi/google/disk/google_disk_service_create_from_snapshot.go
@@ -1,13 +1,23 @@
 package disk
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
+	"strings"
 
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
 
 	"bosh-google-cpi/util"
 )
+
+// ErrSnapshotPermissionDenied is returned by CreateFromSnapshot when GCP rejects the request
+// with a 403, indicating the service account lacks compute.snapshots.useReadOnly permission.
+// Callers that catch this error should return Bosh::Clouds::NotSupported so the BOSH director
+// falls back to the standard copy-based disk update path.
+var ErrSnapshotPermissionDenied = errors.New("compute.snapshots.useReadOnly permission is required to create a disk from snapshot; add the permission to the service account or the disk type change will fall back to the copy path")
 
 // CreateFromSnapshot creates a new disk in zone from snapshotSelfLink with the given size (GiB).
 // diskType must be the full SelfLink URL of the desired disk type (e.g. the value returned by
@@ -32,6 +42,10 @@ func (d GoogleDiskService) CreateFromSnapshot(snapshotSelfLink string, size int,
 	d.logger.Debug(googleDiskServiceLogTag, "Creating Google Disk from snapshot with params: %#v", disk)
 	operation, err := d.computeService.Disks.Insert(d.project, util.ResourceSplitter(zone), disk).Do()
 	if err != nil {
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == http.StatusForbidden &&
+			strings.Contains(strings.ToLower(gerr.Message), "compute.snapshots.usereadonly") {
+			return "", ErrSnapshotPermissionDenied
+		}
 		return "", bosherr.WrapErrorf(err, "Failed to create Google Disk from snapshot")
 	}
 


### PR DESCRIPTION
Merge after Bosh Director PR - https://github.com/cloudfoundry/bosh/pull/2717

Make update_disk backwards compatible: return NotSupported on 403 instead of failing the deployment

When the GCP service account lacks compute.snapshots.useReadOnly, the Disks.Insert call in CreateFromSnapshot returns a 403. Previously this propagated as a generic cloud error and failed the deployment.

Now the 403 is detected before wrapping and returned as a sentinel (disk.ErrSnapshotPermissionDenied). The update_disk action catches this sentinel and returns api.NewInsufficientPermissionsError, which the [Bosh Director will recognise](https://github.com/cloudfoundry/bosh/pull/2717) as Bosh::Clouds::InsufficientPermissions and falls back to the standard copy-based disk update path automatically.

Operators who want the native type-change path can add compute.snapshots.useReadOnly to their service account (see docs/bosh-director-role.yml). Operators who cannot or choose not to add the permission will see the director fall back silently.

PR in Bosh Director to handle this new error type - https://github.com/cloudfoundry/bosh/pull/2717

Created using Claude Code