### PR TITLE
Fix integration test: use pd-balanced instead of hyperdisk-balanced for disk type change test

### DIFF
--- a/src/bosh-google-cpi/integration/disk_test.go
+++ b/src/bosh-google-cpi/integration/disk_test.go
@@ -380,10 +380,10 @@ var _ = Describe("Disk", func() {
 			}`, vmCID, diskCID)
 		assertSucceeds(request)
 
-		By("updating to hyperdisk-balanced type (simulates director calling CPI update_disk)")
+		By("updating to pd-balanced type (simulates director calling CPI update_disk)")
 		request = fmt.Sprintf(`{
 			  "method": "update_disk",
-			  "arguments": ["%v", 32768, {"type": "hyperdisk-balanced"}]
+			  "arguments": ["%v", 32768, {"type": "pd-balanced"}]
 			}`, diskCID)
 		newDiskCID := assertSucceedsWithResult(request).(string)
 		Expect(newDiskCID).ToNot(Equal(diskCID))


### PR DESCRIPTION
The "can update a disk by changing its type via snapshot" integration test was failing because `hyperdisk-balanced` is incompatible with `n1-standard-1` machine types. Changed the target disk type to `pd-balanced`, which is compatible with the VM type used internally by the CPI during snapshot-based disk migration.