### PR TITLE
CI: ensure teardown runs regardless of test outcome

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -4,10 +4,7 @@ groups:
     jobs:
       - test-unit
       - setup-infrastructure
-      - deploy-ubuntu
-      - run-bats
-      - run-int
-      - teardown-infrastructure
+      - deploy-ubuntu-and-run-tests
       - pre-release-fan-in
       - automatically-release-new-patch
       - promote-candidate
@@ -63,66 +60,7 @@ jobs:
       # delete VM created for regional backend service hack
       - in_parallel: *delete_orphaned_vms_step
 
-  - name: teardown-infrastructure
-    serial_groups: [integration]
-    plan:
-      - in_parallel:
-        - get: bosh-google-cpi-release
-          trigger: true
-          passed: [run-bats, run-int]
-        - get: director-creds
-          passed: [run-bats]
-        - get: director-state
-          passed: [deploy-ubuntu]
-        - get: infrastructure
-          trigger: true
-          passed: [run-bats, run-int]
-        - get: stemcell
-          resource: google-ubuntu-stemcell
-          passed: [run-bats, run-int]
-        - get: bosh-cli-registry-image
-        - get: bosh-cli
-          params:
-            globs:
-            - 'bosh-cli-*-linux-amd64'
-        - get: bosh-deployment
-        - get: ci
-        - get: bosh-shared-ci
-        - get: google-cpi-registry-image
-      - do: *delete_orphaned_vms_step
-      - task: build-release
-        file: bosh-shared-ci/tasks/release/create-dev-release.yml
-        image: bosh-cli-registry-image
-        input_mapping:
-          release_repo: bosh-google-cpi-release
-        output_mapping:
-          release_tarball: bosh-cpi-release
-      - task: setup-deployment
-        file: ci/ci/tasks/setup-deployment.yml
-        image: google-cpi-registry-image
-      - task: teardown-director
-        file: ci/ci/tasks/teardown-director.yml
-        image: google-cpi-registry-image
-        params:
-          google_project:                 cloud-foundry-310819
-          google_region:                  us-east1
-          google_zone:                    us-east1-b
-          cpi_source_branch:              master
-          google_test_bucket_name:        bosh-gcp-cpi-release-pipeline-director-env
-          google_subnetwork_range:        "10.0.0.0/24"
-          google_subnetwork_gw:           "10.0.0.1"
-          google_address_static_director: "10.0.0.6"
-          google_json_key_data:           ((gcp_json_key))
-      - put: infrastructure
-        params:
-          env_name: master-bosh-google-cpi
-          terraform_source: ci/ci/test_infrastructure
-          action: destroy
-        get_params:
-          terraform_source: ci/ci/test_infrastructure
-          action: destroy
-
-  - name: deploy-ubuntu
+  - name: deploy-ubuntu-and-run-tests
     serial_groups: [integration]
     plan:
       - in_parallel:
@@ -146,6 +84,8 @@ jobs:
         - get: bosh-shared-ci
         - get: google-cpi-registry-image
         - get: bosh-cli-registry-image
+        - get: bosh-integration-image
+        - get: bats
       - task: build-release
         file: bosh-shared-ci/tasks/release/create-dev-release.yml
         image: bosh-cli-registry-image
@@ -169,109 +109,89 @@ jobs:
           google_subnetwork_gw:           "10.0.0.1"
           google_address_static_director: "10.0.0.6"
           google_json_key_data:           ((gcp_json_key))
-        on_failure:
-          task: teardown-director
-          file: ci/ci/tasks/teardown-director.yml
-          image: google-cpi-registry-image
-          params:
-            google_project:                 cloud-foundry-310819
-            google_region:                  us-east1
-            google_zone:                    us-east1-b
-            cpi_source_branch:              master
-            google_test_bucket_name:        bosh-gcp-cpi-release-pipeline-director-env
-            google_subnetwork_range:        "10.0.0.0/24"
-            google_subnetwork_gw:           "10.0.0.1"
-            google_address_static_director: "10.0.0.6"
-            google_json_key_data:           ((gcp_json_key))
       - put: director-creds
         params:
           file: director-creds/master-creds.yml
       - put: director-state
         params:
           file: director-state/master-manifest-state.json
-
-  - name: run-bats
-    serial: true
-    serial_groups: [integration]
-    plan:
       - in_parallel:
-        - get: bosh-integration-image
-        - get: bosh-google-cpi-release
-          trigger: true
-          passed: [deploy-ubuntu]
-        - get: stemcell
-          resource: google-ubuntu-stemcell
-          trigger: true
-          passed: [deploy-ubuntu]
-        - get: director-creds
-          trigger: true
-          passed: [deploy-ubuntu]
-        - get: infrastructure
-          trigger: true
-          passed: [deploy-ubuntu]
-        - get: bats
-        - get: bosh-cli
+        - do:
+          - task: prepare-bats-config
+            file: ci/ci/tasks/prepare-bats-config.yml
+            image: bosh-integration-image
+            params:
+              cpi_source_branch:       master
+              google_subnetwork_range: "10.0.0.0/24"
+              stemcell_name:           bosh-google-kvm-ubuntu-noble
+          - task: run-bats
+            file: bats/ci/tasks/run-bats.yml
+        - do:
+          - put: sole-tenancy-infrastructure
+            params:
+              env_name: master-bosh-google-cpi-sole-tenancy
+              terraform_source: ci/ci/sole_tenancy_infrastructure
+          - task: run-int
+            file: ci/ci/tasks/run-int.yml
+            image: google-cpi-registry-image
+            params:
+              google_json_key_data:      ((integration_gcp_credentials_json))
+              google_address_static_int: "10.0.0.100,10.0.0.101,10.0.0.102"
+            ensure:
+              put: sole-tenancy-infrastructure
+              params:
+                action: destroy
+                env_name: master-bosh-google-cpi-sole-tenancy
+                terraform_source: ci/ci/sole_tenancy_infrastructure
+              get_params:
+                action: destroy
+                terraform_source: ci/ci/sole_tenancy_infrastructure
+    ensure:
+      do:
+        - do: *delete_orphaned_vms_step
+        - try:
+            do:
+              - task: build-release-for-teardown
+                file: bosh-shared-ci/tasks/release/create-dev-release.yml
+                image: bosh-cli-registry-image
+                input_mapping:
+                  release_repo: bosh-google-cpi-release
+                output_mapping:
+                  release_tarball: bosh-cpi-release
+              - task: setup-deployment
+                file: ci/ci/tasks/setup-deployment.yml
+                image: google-cpi-registry-image
+              - task: teardown-director
+                file: ci/ci/tasks/teardown-director.yml
+                image: google-cpi-registry-image
+                params:
+                  google_project:                 cloud-foundry-310819
+                  google_region:                  us-east1
+                  google_zone:                    us-east1-b
+                  cpi_source_branch:              master
+                  google_test_bucket_name:        bosh-gcp-cpi-release-pipeline-director-env
+                  google_subnetwork_range:        "10.0.0.0/24"
+                  google_subnetwork_gw:           "10.0.0.1"
+                  google_address_static_director: "10.0.0.6"
+                  google_json_key_data:           ((gcp_json_key))
+        - put: infrastructure
           params:
-            globs:
-            - 'bosh-cli-*-linux-amd64'
-        - get: ci
-      - task: prepare-bats-config
-        file: ci/ci/tasks/prepare-bats-config.yml
-        image: bosh-integration-image
-        params:
-          cpi_source_branch:       master
-          google_subnetwork_range: "10.0.0.0/24"
-          stemcell_name:           bosh-google-kvm-ubuntu-noble
-      - task: run-bats
-        file: bats/ci/tasks/run-bats.yml
-
-  - name: run-int
-    serial_groups: [integration]
-    plan:
-      - in_parallel:
-        - get: bosh-google-cpi-release
-          trigger: true
-          passed: [deploy-ubuntu]
-        - get: stemcell
-          resource: google-ubuntu-stemcell
-          trigger: true
-          passed: [deploy-ubuntu]
-        - get: infrastructure
-          trigger: true
-          passed: [deploy-ubuntu]
-        - get: ci
-        - get: google-cpi-registry-image
-      - put: sole-tenancy-infrastructure
-        params:
-          env_name: master-bosh-google-cpi-sole-tenancy
-          terraform_source: ci/ci/sole_tenancy_infrastructure
-      - task: run-int
-        file: ci/ci/tasks/run-int.yml
-        image: google-cpi-registry-image
-        params:
-          google_json_key_data:      ((integration_gcp_credentials_json))
-          google_address_static_int: "10.0.0.100,10.0.0.101,10.0.0.102"
-        ensure:
-          put: sole-tenancy-infrastructure
-          params:
+            env_name: master-bosh-google-cpi
+            terraform_source: ci/ci/test_infrastructure
             action: destroy
-            env_name: master-bosh-google-cpi-sole-tenancy
-            terraform_source: ci/ci/sole_tenancy_infrastructure
           get_params:
+            terraform_source: ci/ci/test_infrastructure
             action: destroy
-            terraform_source: ci/ci/sole_tenancy_infrastructure
 
   - name: pre-release-fan-in
     plan:
     - get: bosh-google-cpi-release
       trigger: true
       passed:
-      - run-int
-      - run-bats
+      - deploy-ubuntu-and-run-tests
     - get: google-ubuntu-stemcell
       passed:
-      - run-int
-      - run-bats
+      - deploy-ubuntu-and-run-tests
 
   - name: automatically-release-new-patch
     serial_groups: [version]


### PR DESCRIPTION
### Problem

When `run-bats` or `run-int` fails, the `teardown-infrastructure` job never triggers because Concourse's `passed` constraint only matches **successful** builds (it queries the `successful_build_outputs` table internally). This leaves the BOSH director VM and its static external IP allocated, causing the next pipeline run to fail with:

```log
CPI 'create_vm' method responded with error: CmdError{
  "type":"Bosh::Clouds::VMCreationFailed",
  "message":"VM failed to create: googleapi: Error 400: Invalid resource usage:
    'External IP address: xxx.xxx.xxx.xxx is already in-use.'., invalidResourceUsage",
  "ok_to_retry":true
}
```

This requires manual cleanup every time a test fails.

### Solution

Merge `deploy-ubuntu`, `run-bats`, `run-int`, and `teardown-infrastructure` into a single `deploy-ubuntu-and-run-tests` job with a job-level `ensure` block that guarantees cleanup.

**Key design decisions:**

| Aspect               | Approach                                                                                                                                                       |
|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Test parallelism     | `run-bats` and `run-int` execute in parallel via `in_parallel` (`fail_fast` defaults to `false`, so both run to completion even if one fails)                  |
| Guaranteed cleanup   | Job-level `ensure` always runs: deletes orphaned VMs, tears down the director, and destroys terraform infrastructure                                           |
| Partial failures     | Teardown wrapped in `try` so that infrastructure destroy proceeds even if the director state is missing (e.g., `setup-director` failed before creating the VM) |
| Sole-tenancy cleanup | Preserved via nested `ensure` on `run-int` (unchanged behavior)                                                                                                |


### Pipeline structure (before → after)

**Before:**

```
test-unit → setup-infrastructure → deploy-ubuntu → run-bats ──┐
                                                   run-int  ──┤→ teardown-infrastructure → pre-release-fan-in
```

`teardown-infrastructure` only ran if both test jobs succeeded.

**After:**

```
test-unit → setup-infrastructure → deploy-ubuntu-and-run-tests → pre-release-fan-in
                                        │
                                        ├─ setup-director
                                        ├─ in_parallel: [run-bats, run-int]
                                        └─ ensure: teardown (always runs)
```

### Trade-offs

- Separate `run-bats` / `run-int` jobs are no longer visible as individual boxes in the pipeline UI, but individual task pass/fail is still visible within the job
- The job is longer-running since it encompasses deploy + tests + teardown, but total wall-clock time is similar (tests still run in parallel)

---

Implemented with ClaudeAI.