### PR TITLE
CI: don't run tests in parallel to avoid conflicts

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -115,37 +115,35 @@ jobs:
       - put: director-state
         params:
           file: director-state/master-manifest-state.json
-      - in_parallel:
-        - do:
-          - task: prepare-bats-config
-            file: ci/ci/tasks/prepare-bats-config.yml
-            image: bosh-integration-image
-            params:
-              cpi_source_branch:       master
-              google_subnetwork_range: "10.0.0.0/24"
-              stemcell_name:           bosh-google-kvm-ubuntu-noble
-          - task: run-bats
-            file: bats/ci/tasks/run-bats.yml
-        - do:
-          - put: sole-tenancy-infrastructure
-            params:
-              env_name: master-bosh-google-cpi-sole-tenancy
-              terraform_source: ci/ci/sole_tenancy_infrastructure
-          - task: run-int
-            file: ci/ci/tasks/run-int.yml
-            image: google-cpi-registry-image
-            params:
-              google_json_key_data:      ((integration_gcp_credentials_json))
-              google_address_static_int: "10.0.0.100,10.0.0.101,10.0.0.102"
-            ensure:
-              put: sole-tenancy-infrastructure
-              params:
-                action: destroy
-                env_name: master-bosh-google-cpi-sole-tenancy
-                terraform_source: ci/ci/sole_tenancy_infrastructure
-              get_params:
-                action: destroy
-                terraform_source: ci/ci/sole_tenancy_infrastructure
+      - task: prepare-bats-config
+        file: ci/ci/tasks/prepare-bats-config.yml
+        image: bosh-integration-image
+        params:
+          cpi_source_branch:       master
+          google_subnetwork_range: "10.0.0.0/24"
+          stemcell_name:           bosh-google-kvm-ubuntu-noble
+      - task: run-bats
+        file: bats/ci/tasks/run-bats.yml
+        image: bosh-integration-image
+      - put: sole-tenancy-infrastructure
+        params:
+          env_name: master-bosh-google-cpi-sole-tenancy
+          terraform_source: ci/ci/sole_tenancy_infrastructure
+      - task: run-int
+        file: ci/ci/tasks/run-int.yml
+        image: google-cpi-registry-image
+        params:
+          google_json_key_data:      ((integration_gcp_credentials_json))
+          google_address_static_int: "10.0.0.100,10.0.0.101,10.0.0.102"
+        ensure:
+          put: sole-tenancy-infrastructure
+          params:
+            action: destroy
+            env_name: master-bosh-google-cpi-sole-tenancy
+            terraform_source: ci/ci/sole_tenancy_infrastructure
+          get_params:
+            action: destroy
+            terraform_source: ci/ci/sole_tenancy_infrastructure
     ensure:
       do:
         - do: *delete_orphaned_vms_step


### PR DESCRIPTION
Follow up to #391. Two changes:

1. **Don't run tests in parallel** - running BATs and integration tests concurrently creates resource conflicts that cause failures. Tests now run sequentially.
2. **Explicit image on `run-bats`** - required after cloudfoundry/bosh-acceptance-tests#62 removed the default image from the task definition.

Both changes have already been applied to the pipeline.