### PR TITLE
CI: replace deprecated docker-image resource with oci-build-task

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -334,9 +334,26 @@ jobs:
         - get: bosh-golang-release-image
         - get: weekly
           trigger: true
-      - put: google-cpi-image
+      - task: build-image
+        privileged: true
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source:
+              repository: concourse/oci-build-task
+          inputs:
+            - name: bosh-google-cpi-release
+          outputs:
+            - name: image
+          params:
+            CONTEXT: bosh-google-cpi-release/ci/docker/bosh-google-cpi-boshrelease
+            DOCKERFILE: bosh-google-cpi-release/ci/docker/bosh-google-cpi-boshrelease/Dockerfile
+          run:
+            path: build
+      - put: google-cpi-registry-image
         params:
-          build: "bosh-google-cpi-release/ci/docker/bosh-google-cpi-boshrelease"
+          image: image/image.tar
         get_params:
           skip_download: true
 
@@ -557,13 +574,7 @@ resources:
     type: registry-image
     source:
       repository: foundationalinfrastructure/gce-cpi-release
-      username: ((dockerhub_username))
-      password: ((dockerhub_password))
-
-  - name: google-cpi-image
-    type: docker-image
-    source:
-      repository: foundationalinfrastructure/gce-cpi-release
+      tag: latest
       username: ((dockerhub_username))
       password: ((dockerhub_password))
 


### PR DESCRIPTION
Replace the `docker-image` resource in the `build-dockerfile` job with the canonical Concourse pattern: [`concourse/oci-build-task`][1] to build, then the existing `google-cpi-registry-image` (`registry-image` type) to push.

[1]: https://github.com/concourse/oci-build-task#migrating-from-the-docker-image-resource

The `docker-image` resource bundles a deprecated `docker build` toolchain that emits this warning on every run:

```
Login Succeeded
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            BuildKit is currently disabled; enable it by removing the DOCKER_BUILDKIT=0
            environment-variable.
```

It also silently discards stderr from `docker push`, which made builds fail opaquely. And we couldn't easily investigate the issue.

Side changes required by the new resource: tag `latest` is now explicit on the `google-cpi-registry-image` source, and the unused `google-cpi-image` resource is removed.

Verified working on [103.1](https://bosh.ci.cloudfoundry.org/teams/main/pipelines/bosh-google-cpi/jobs/build-dockerfile/builds/103.1) run.