### PR TITLE
CI: fix setup director failure

### DIFF
--- a/ci/docker/bosh-google-cpi-boshrelease/Dockerfile
+++ b/ci/docker/bosh-google-cpi-boshrelease/Dockerfile
@@ -48,6 +48,6 @@ RUN bosh_bin_path="/usr/bin/bosh" \
       > "${bosh_bin_path}" \
     && chmod +x "${bosh_bin_path}"
 
-RUN useradd non-root-user --shell /bin/bash --create-home \
+RUN useradd non-root-user --uid 2000 --shell /bin/bash --create-home \
     && echo "non-root-user ALL=(ALL) NOPASSWD: ALL" \
       >> /etc/sudoers


### PR DESCRIPTION
## Problem

The `setup-director` CI task was failing with `mkdir: Permission denied` when trying to create `$HOME/.config/gcloud/`. The task runs as `non-root-user` but `$HOME` was owned by a different uid, making it unwritable:

```
Uid: ( 1002/ UNKNOWN)   Gid: ( 1001/non-root-user)
DIAG: writable check: no
mkdir: Permission denied
```

## Root cause

The Dockerfile switched from `ubuntu:jammy` to `ubuntu` (noble) in [476e7c4](https://github.com/cloudfoundry/bosh-google-cpi-release/commit/476e7c499840920cd2d5708bdba20e3a109967de).
On noble, the `ubuntu` user is pre-created at uid 1000, so `useradd non-root-user` without an explicit uid gets assigned uid 1001. On jammy, `non-root-user` was assigned uid 1000 and the issue was not observed.

The uid mismatch between the running process (uid 1001) and `$HOME` ownership (uid 1002 or higher) occurs when the image is used in Concourse tasks.

## Fix

Pin `non-root-user` to uid 2000, which is above the typical remapping range:

```dockerfile
RUN useradd non-root-user --uid 2000 --shell /bin/bash --create-home \
```

After the fix, `$HOME` is correctly owned by `non-root-user:non-root-user` and the writable check passes:

```
Uid: ( 2000/non-root-user)   Gid: ( 2000/non-root-user)
DIAG: writable check: yes
```

## Testing

- Rebuilt the CI image with `--uid 2000`
- Triggered `deploy-ubuntu-and-run-tests` - `setup-director` passes
- Confirmed in task output that uid 2000 is applied and `$HOME` is writable
