### PR TITLE
CI: fetch google-cpi-registry-image before in_parallel to avoid uid shift

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -63,6 +63,7 @@ jobs:
   - name: deploy-ubuntu-and-run-tests
     serial_groups: [integration]
     plan:
+      - get: google-cpi-registry-image
       - in_parallel:
         - get: bosh-google-cpi-release
           trigger: true
@@ -82,7 +83,6 @@ jobs:
         - get: bosh-deployment
         - get: ci
         - get: bosh-shared-ci
-        - get: google-cpi-registry-image
         - get: bosh-cli-registry-image
         - get: bosh-integration-image
         - get: bats


### PR DESCRIPTION
Workaround for a Concourse bug where fetching multiple registry-image resources in the same in_parallel block causes a uid shift on one of the btrfs subvolumes, making the home directory of non-root users unwritable at runtime.

See: https://github.com/concourse/concourse/issues/9662
Workaround for /issues/395